### PR TITLE
Fix url and release v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,6 @@ The double click detection is based on tips & code from `medo64` (from this repo
 
 [0.1.1](https://github.com/grahammkelly/wrapstatus-vscode-extension/tree/0.1.1) Same as 0.1.0, however removed the browser extension files (not working and I don't use `vscode.dev` enough to be bothered investigating)
 
-[0.1.2](https://github.com/grahammkelly/wrapstatus-vscode-extension/tree/v0.1.2) Added eslint action to the repository, updated README. No functional changes
+[v0.1.2](https://github.com/grahammkelly/wrapstatus-vscode-extension/tree/v0.1.2) Added eslint action to the repository, updated README. No functional changes
+
+[v0.1.3](https://github.com/grahammkelly/wrapstatus-vscode-extension/tree/v0.1.3) Updated URL for release 0.1.2 in README, no other changes

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ The double click detection is based on tips & code from `medo64` (from this repo
 
 [0.1.1](https://github.com/grahammkelly/wrapstatus-vscode-extension/tree/0.1.1) Same as 0.1.0, however removed the browser extension files (not working and I don't use `vscode.dev` enough to be bothered investigating)
 
-[0.1.2](https://github.com/grahammkelly/wrapstatus-vscode-extension/tree/0.1.2) Added eslint action to the repository, updated README. No functional changes
+[0.1.2](https://github.com/grahammkelly/wrapstatus-vscode-extension/tree/v0.1.2) Added eslint action to the repository, updated README. No functional changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordwrap-status",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {


### PR DESCRIPTION
No functional changes. Only performing a release so docs are up to date on the extension page